### PR TITLE
got should be aware of proxy related environment variables like HTTP_PROXY

### DIFF
--- a/got.go
+++ b/got.go
@@ -96,6 +96,7 @@ func (d *Download) Init() error {
 			MaxIdleConns:        10,
 			IdleConnTimeout:     30 * time.Second,
 			TLSHandshakeTimeout: 5 * time.Second,
+			Proxy: http.ProxyFromEnvironment,
 		},
 		CheckRedirect: func(req *http.Request, via []*http.Request) error {
 			d.redirected = true


### PR DESCRIPTION
Both `curl` and the default Go `http.Client` detects environment variables like `HTTP_PROXY` automatically. I think it would be nice if `got` do the same.