### PR TITLE
Adding context.Context as parameter to Download.Start and Cancellation to the main Binary

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 dist/
+.vscode/

--- a/chunks_test.go
+++ b/chunks_test.go
@@ -2,12 +2,14 @@ package got
 
 import (
 	"testing"
+
+	"golang.org/x/net/context"
 )
 
 func TestChunksLength(t *testing.T) {
 
-	d, err := New(Config{
-		URL:  "http://speedtest.ftp.otenet.gr/files/test10Mb.db",
+	d, err := New(context.Background(), Config{
+		URL:          "http://speedtest.ftp.otenet.gr/files/test10Mb.db",
 		MinChunkSize: 5242870,
 	})
 

--- a/chunks_test.go
+++ b/chunks_test.go
@@ -6,13 +6,13 @@ import (
 
 func TestChunksLength(t *testing.T) {
 
-	d := &Download{
-		URL:          "http://speedtest.ftp.otenet.gr/files/test10Mb.db",
+	d, err := New(Config{
+		URL:  "http://speedtest.ftp.otenet.gr/files/test10Mb.db",
 		MinChunkSize: 5242870,
-	}
+	})
 
-	if err := d.Init(); err != nil {
-
+	// init
+	if err != nil {
 		t.Error(err)
 		return
 	}

--- a/go.mod
+++ b/go.mod
@@ -6,5 +6,6 @@ require (
 	github.com/apoorvam/goterminal v0.0.0-20180523175556-614d345c47e5
 	github.com/dustin/go-humanize v1.0.0
 	github.com/mattn/go-isatty v0.0.12 // indirect
+	golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc
 	golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208
 )

--- a/go.sum
+++ b/go.sum
@@ -4,7 +4,16 @@ github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/mattn/go-isatty v0.0.12 h1:wuysRhFDzyxgEmMf5xjvJ2M9dZoWAXNNr5LSBS7uHXY=
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/crypto v0.0.0-20200622213623-75b288015ac9/go.mod h1:LzIPMQfyMNhhGPhUkYOs5KpL4U8rLKemX1yGLhDgUto=
+golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc h1:zK/HqS5bZxDptfPJNq8v7vJfXtkU7r9TLIoSr1bXaP4=
+golang.org/x/net v0.0.0-20200813134508-3edf25e44fcc/go.mod h1:/O7V0waA8r7cgGh81Ro3o1hOxt32SMVPicZroKQ2sZA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208 h1:qwRHBd0NqMbJxfbotnDhm2ByMI1Shq4Y6oRJo21SGJA=
 golang.org/x/sync v0.0.0-20200625203802-6e8e738ad208/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
+golang.org/x/sys v0.0.0-20190412213103-97732733099d/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42 h1:vEOn+mP2zCOVzKckCZy6YsCtDblrpj/w7B9nxGNELpg=
 golang.org/x/sys v0.0.0-20200116001909-b77594299b42/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20200323222414-85ca7c5b95cd/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=

--- a/got.go
+++ b/got.go
@@ -2,7 +2,6 @@ package got
 
 import (
 	"context"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -14,29 +13,10 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// ErrDownloadAborted - When download is aborted by the OS before it is completed, ErrDownloadAborted will be triggered
-var ErrDownloadAborted error = errors.New("Operation aborted")
-
 type (
-
-	// Info of the download url.
-	Info struct {
-
-		// File content length.
-		Length uint64
-
-		// Supports partial content?
-		Rangeable bool
-
-		// URL Redirected.
-		Redirected bool
-	}
-
-	// Download represents the download URL.
-	Download struct {
-
-		// Download file info.
-		Info
+	Config struct {
+		// Context...
+		Context context.Context
 
 		// URL to download.
 		URL string
@@ -53,14 +33,35 @@ type (
 		// Set min chunk size.
 		MinChunkSize uint64
 
+		// Progress interval in ms.
+		Interval uint64
+
 		// Max chunks to download at same time.
 		Concurrency uint
+	}
+
+	// Info of the download url.
+	Info struct {
+
+		// File content length.
+		Length uint64
+
+		// Supports partial content?
+		Rangeable bool
+
+		// URL Redirected.
+		Redirected bool
+	}
+
+	// Download represents the download URL.
+	Download struct {
+		// Download file info.
+		Info
+
+		Config
 
 		// Progress...
 		Progress *Progress
-
-		// Progress interval in ms.
-		Interval uint64
 
 		// Download file chunks.
 		chunks []Chunk
@@ -73,9 +74,195 @@ type (
 	}
 )
 
+// Start downloading.
+func (d *Download) Start() (err error) {
+	stop := make(chan struct{})
+	defer close(stop)
+	// Create a new temp dir for this download.
+	temp, err := ioutil.TempDir("", "GotChunks")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(temp)
+
+	// Run progress func.
+	go d.Progress.Run(d.Context, d)
+
+	// Partial content not supported,
+	// just download the file in one chunk.
+	if len(d.chunks) == 0 {
+
+		file, err := os.Create(d.Dest)
+
+		if err != nil {
+			return err
+		}
+
+		defer file.Close()
+
+		chunk := &Chunk{
+			Progress: d.Progress,
+		}
+
+		return chunk.Download(d.URL, d.client, file)
+	}
+
+	eg, ctx := errgroup.WithContext(d.Context)
+
+	go func() {
+		select {
+		case <-d.Context.Done():
+			// System or user interrupted the program
+			_ = os.Remove(d.Dest)
+			return
+		case <-stop:
+			// Everything went ok, no interruptions
+			return
+		}
+	}()
+
+	// Download chunks.
+	eg.Go(func() error {
+		return d.dl(ctx, temp)
+	})
+
+	// Merge chunks.
+	eg.Go(func() error {
+		return d.merge(ctx)
+	})
+
+	// Wait for chunks...
+	if err := eg.Wait(); err != nil {
+		// In case of an error, destination file should be removed
+		_ = os.Remove(d.Dest)
+		return err
+	}
+
+	// Update progress output after chunks finished.
+	if d.Progress.ProgressFunc != nil {
+		d.Progress.ProgressFunc(d.Progress, d)
+	}
+
+	stop <- struct{}{}
+	return nil
+
+}
+
+// GetInfo gets Info, it returns error if status code > 500 or 404.
+func (d *Download) GetInfo() (Info, error) {
+
+	req, err := NewRequest(http.MethodHead, d.URL)
+
+	if err != nil {
+		return Info{}, err
+	}
+
+	res, err := d.client.Do(req)
+
+	if err != nil {
+		return Info{}, err
+	}
+
+	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
+
+		// On 4xx HEAD request (work around for #3).
+		if res.StatusCode != 404 && res.StatusCode >= 400 && res.StatusCode < 500 {
+			return Info{}, nil
+		}
+
+		return Info{}, fmt.Errorf("Response status code is not ok: %d", res.StatusCode)
+	}
+
+	return Info{
+		Length:     uint64(res.ContentLength),
+		Rangeable:  res.Header.Get("accept-ranges") == "bytes",
+		Redirected: d.redirected,
+	}, nil
+}
+
+// Merge downloaded chunks.
+func (d *Download) merge(ctx context.Context) error {
+
+	file, err := os.Create(d.Dest)
+	if err != nil {
+		return err
+	}
+
+	defer file.Close()
+
+	for i := range d.chunks {
+
+		select {
+		case <-d.chunks[i].Done:
+		case <-ctx.Done():
+			return nil
+		}
+
+		chunk, err := os.Open(d.chunks[i].Path)
+		if err != nil {
+			return err
+		}
+
+		if _, err = io.Copy(file, chunk); err != nil {
+			return err
+		}
+
+		// Non-blocking chunk close.
+		go chunk.Close()
+
+		// Sync dest file.
+		_ = file.Sync()
+	}
+	return nil
+}
+
+// Download chunks
+func (d *Download) dl(ctx context.Context, temp string) error {
+
+	eg, ctx := errgroup.WithContext(ctx)
+
+	// Concurrency limit.
+	max := make(chan int, d.Concurrency)
+
+	for i := 0; i < len(d.chunks); i++ {
+
+		max <- 1
+		current := i
+
+		eg.Go(func() error {
+
+			defer func() {
+				<-max
+			}()
+
+			// Create chunk in temp dir.
+			chunk, err := os.Create(filepath.Join(temp, fmt.Sprintf("chunk-%d", current)))
+
+			if err != nil {
+				return err
+			}
+
+			// Close chunk fd.
+			defer chunk.Close()
+
+			// Download chunk.
+			err = d.chunks[current].Download(d.URL, d.client, chunk)
+			if err != nil {
+				return err
+			}
+
+			d.chunks[current].Path = chunk.Name()
+			close(d.chunks[current].Done)
+			return nil
+		})
+	}
+
+	return eg.Wait()
+}
+
 // Init set defaults and split file into chunks and gets Info,
 // you should call Init before Start
-func (d *Download) Init() error {
+func (d *Download) init() error {
 
 	var (
 		err                                error
@@ -195,195 +382,18 @@ func (d *Download) Init() error {
 	return nil
 }
 
-// Start downloading.
-func (d *Download) Start(ctx context.Context) (err error) {
-
-	// Create a new temp dir for this download.
-	temp, err := ioutil.TempDir("", "GotChunks")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(temp)
-	select {
-	case <-ctx.Done():
-		err = os.Remove(d.Dest)
-		if err != nil {
-			return err
-		}
-		return ErrDownloadAborted
-	default:
-		// Run progress func.
-		go d.Progress.Run(ctx, d)
-
-		// Partial content not supported,
-		// just download the file in one chunk.
-		if len(d.chunks) == 0 {
-
-			file, err := os.Create(d.Dest)
-
-			if err != nil {
-				return err
-			}
-
-			defer file.Close()
-
-			chunk := &Chunk{
-				Progress: d.Progress,
-			}
-
-			return chunk.Download(d.URL, d.client, file)
-		}
-
-		eg, ctx := errgroup.WithContext(ctx)
-
-		// Download chunks.
-		eg.Go(func() error {
-			return d.dl(ctx, temp)
-		})
-
-		// Merge chunks.
-		eg.Go(func() error {
-			return d.merge(ctx)
-		})
-
-		// Wait for chunks...
-		if err := eg.Wait(); err != nil {
-			// In case of an error, destination file should be removed
-			_ = os.Remove(d.Dest)
-			return err
-		}
-
-		// Update progress output after chunks finished.
-		if d.Progress.ProgressFunc != nil {
-			d.Progress.ProgressFunc(d.Progress, d)
-		}
-
-		return nil
-	}
-
-}
-
-// GetInfo gets Info, it returns error if status code > 500 or 404.
-func (d *Download) GetInfo() (Info, error) {
-
-	req, err := NewRequest(http.MethodHead, d.URL)
-
-	if err != nil {
-		return Info{}, err
-	}
-
-	res, err := d.client.Do(req)
-
-	if err != nil {
-		return Info{}, err
-	}
-
-	if res.StatusCode < http.StatusOK || res.StatusCode >= http.StatusBadRequest {
-
-		// On 4xx HEAD request (work around for #3).
-		if res.StatusCode != 404 && res.StatusCode >= 400 && res.StatusCode < 500 {
-			return Info{}, nil
-		}
-
-		return Info{}, fmt.Errorf("Response status code is not ok: %d", res.StatusCode)
-	}
-
-	return Info{
-		Length:     uint64(res.ContentLength),
-		Rangeable:  res.Header.Get("accept-ranges") == "bytes",
-		Redirected: d.redirected,
-	}, nil
-}
-
-// Merge downloaded chunks.
-func (d *Download) merge(ctx context.Context) error {
-
-	file, err := os.Create(d.Dest)
-	if err != nil {
-		return err
-	}
-
-	defer file.Close()
-
-	for i := range d.chunks {
-
-		select {
-		case <-d.chunks[i].Done:
-		case <-ctx.Done():
-			return nil
-		}
-
-		chunk, err := os.Open(d.chunks[i].Path)
-		if err != nil {
-			return err
-		}
-
-		if _, err = io.Copy(file, chunk); err != nil {
-			return err
-		}
-
-		// Non-blocking chunk close.
-		go chunk.Close()
-
-		// Sync dest file.
-		file.Sync()
-	}
-	return nil
-}
-
-// Download chunks
-func (d *Download) dl(ctx context.Context, temp string) error {
-
-	eg, ctx := errgroup.WithContext(ctx)
-
-	// Concurrency limit.
-	max := make(chan int, d.Concurrency)
-
-	for i := 0; i < len(d.chunks); i++ {
-
-		max <- 1
-		current := i
-
-		eg.Go(func() error {
-
-			defer func() {
-				<-max
-			}()
-
-			// Create chunk in temp dir.
-			chunk, err := os.Create(filepath.Join(temp, fmt.Sprintf("chunk-%d", current)))
-
-			if err != nil {
-				return err
-			}
-
-			// Close chunk fd.
-			defer chunk.Close()
-
-			// Download chunk.
-			err = d.chunks[current].Download(d.URL, d.client, chunk)
-			if err != nil {
-				return err
-			}
-
-			d.chunks[current].Path = chunk.Name()
-			close(d.chunks[current].Done)
-			return nil
-		})
-	}
-
-	return eg.Wait()
-}
-
 // New creates a new Download and calls Init.
-func New(url string, dest string) (*Download, error) {
+func New(cfg Config) (*Download, error) {
 
 	d := &Download{
-		URL:  url,
-		Dest: dest,
+		Config: cfg,
 	}
 
-	if err := d.Init(); err != nil {
+	if d.Context == nil {
+		d.Context = context.Background()
+	}
+
+	if err := d.init(); err != nil {
 		return nil, err
 	}
 

--- a/got.go
+++ b/got.go
@@ -14,8 +14,8 @@ import (
 	"golang.org/x/sync/errgroup"
 )
 
-// ErrInterupted when user or system interrupts the program
-var ErrInterupted = errors.New("Interupted")
+// ErrDownloadAborted - When download is aborted by the OS before it is completed, ErrDownloadAborted will be triggered
+var ErrDownloadAborted = errors.New("Operation aborted")
 
 // GetChunkSize gets size of individual chanck
 func (d *Download) GetChunkSize() uint64 {
@@ -60,7 +60,7 @@ func (d *Download) Start() (err error) {
 	go func() {
 		select {
 		case <-d.ctx.Done():
-			errs <- ErrInterupted
+			errs <- ErrDownloadAborted
 			// System or user interrupted the program
 			return
 		case <-stop:
@@ -156,7 +156,7 @@ func (d *Download) merge(ctx context.Context) error {
 			// Sync dest file.
 			_ = file.Sync()
 		case <-ctx.Done():
-			return ErrInterupted
+			return ErrDownloadAborted
 		}
 	}
 	return nil

--- a/got_test.go
+++ b/got_test.go
@@ -45,7 +45,7 @@ func TestGot(t *testing.T) {
 				return
 			}
 
-			fmt.Fprint(w, "helloworld")
+			_, _ = fmt.Fprint(w, "helloworld")
 			return
 
 		case "/file4":
@@ -137,7 +137,7 @@ func getInfoTest(t *testing.T, url string, expect got.Info) {
 	tmpFile := createTemp()
 	defer clean(tmpFile)
 
-	d, err := got.New(got.Config{
+	d, err := got.New(context.Background(), got.Config{
 		URL:  url,
 		Dest: tmpFile,
 	})
@@ -165,7 +165,7 @@ func initTest(t *testing.T, url string) {
 	tmpFile := createTemp()
 	defer clean(tmpFile)
 
-	_, err := got.New(got.Config{
+	_, err := got.New(context.Background(), got.Config{
 		URL:  url,
 		Dest: tmpFile,
 	})
@@ -180,7 +180,7 @@ func downloadChunksTest(t *testing.T, url string, size uint64) {
 	tmpFile := createTemp()
 	defer clean(tmpFile)
 
-	d, err := got.New(got.Config{
+	d, err := got.New(context.Background(), got.Config{
 		URL:  url,
 		Dest: tmpFile,
 	})
@@ -208,7 +208,7 @@ func downloadTest(t *testing.T, url string, size int64) {
 	tmpFile := createTemp()
 	defer clean(tmpFile)
 
-	d, err := got.New(got.Config{
+	d, err := got.New(context.Background(), got.Config{
 		URL:  url,
 		Dest: tmpFile,
 	})
@@ -239,7 +239,7 @@ func downloadNotFoundTest(t *testing.T, url string) {
 	tmpFile := createTemp()
 	defer clean(tmpFile)
 
-	_, err := got.New(got.Config{
+	_, err := got.New(context.Background(), got.Config{
 		URL:  url,
 		Dest: tmpFile,
 	})
@@ -255,7 +255,7 @@ func downloadHeadNotSupported(t *testing.T, url string) {
 	tmpFile := createTemp()
 	defer clean(tmpFile)
 
-	d, err := got.New(got.Config{
+	d, err := got.New(context.Background(), got.Config{
 		URL:  url,
 		Dest: tmpFile,
 	})
@@ -284,7 +284,7 @@ func downloadPartialContentNotSupportedTest(t *testing.T, url string) {
 	tmpFile := createTemp()
 	defer clean(tmpFile)
 
-	d, err := got.New(got.Config{
+	d, err := got.New(context.Background(), got.Config{
 		URL:  url,
 		Dest: tmpFile,
 	})
@@ -319,10 +319,9 @@ func fileContentTest(t *testing.T, url string) {
 	tmpFile := createTemp()
 	defer clean(tmpFile)
 
-	d, err := got.New(got.Config{
-		URL:       url,
-		Dest:      tmpFile,
-		ChunkSize: 10,
+	d, err := got.New(context.Background(), got.Config{
+		URL:  url,
+		Dest: tmpFile,
 	})
 
 	if err != nil {
@@ -364,10 +363,9 @@ func downloadCancelTest(t *testing.T, url string) {
 	defer clean(tmpFile)
 	defer cancel()
 
-	d, err := got.New(got.Config{
-		Context: ctx,
-		URL:     url,
-		Dest:    tmpFile,
+	d, err := got.New(ctx, got.Config{
+		URL:  url,
+		Dest: tmpFile,
 	})
 
 	// init
@@ -376,9 +374,12 @@ func downloadCancelTest(t *testing.T, url string) {
 		return
 	}
 	if err := d.Start(); err != nil {
+		if err != got.ErrInterupted {
+			t.Error("Program is not interrupted")
+		}
 		_, err := os.Stat(tmpFile)
 		if !os.IsNotExist(err) {
-			t.Errorf("Download file is not deleted")
+			t.Error("Download file is not deleted")
 			return
 		}
 	}
@@ -399,6 +400,5 @@ func createTemp() string {
 }
 
 func clean(tmpFile string) {
-
-	os.Remove(tmpFile)
+	_ = os.Remove(tmpFile)
 }

--- a/got_test.go
+++ b/got_test.go
@@ -374,7 +374,7 @@ func downloadCancelTest(t *testing.T, url string) {
 		return
 	}
 	if err := d.Start(); err != nil {
-		if err != got.ErrInterupted {
+		if err != got.ErrDownloadAborted {
 			t.Error("Program is not interrupted")
 		}
 		_, err := os.Stat(tmpFile)

--- a/types.go
+++ b/types.go
@@ -1,0 +1,68 @@
+package got
+
+import (
+	"context"
+	"net/http"
+)
+
+type (
+	Config struct {
+
+		// URL to download.
+		URL string
+
+		// File destination.
+		Dest string
+
+		// Set maximum chunk size.
+		MaxChunkSize uint64
+
+		// Set min chunk size.
+		MinChunkSize uint64
+
+		// Progress interval in ms.
+		Interval uint64
+
+		// Max chunks to download at same time.
+		Concurrency uint
+	}
+
+	// Info of the download url.
+	Info struct {
+
+		// File content length.
+		Length uint64
+
+		// Supports partial content?
+		Rangeable bool
+
+		// URL Redirected.
+		Redirected bool
+	}
+
+	// Download represents the download URL.
+	Download struct {
+		// Download file info.
+		Info
+
+		Config
+
+		// Progress...
+		Progress *Progress
+
+		// Download file chunks.
+		chunks []Chunk
+
+		// Http client.
+		client *http.Client
+
+		// Is the URL redirected to a different location.
+		redirected bool
+
+		// Split file into chunks by ChunkSize in bytes.
+		chunkSize uint64
+
+		// Context...
+		ctx context.Context
+	}
+)


### PR DESCRIPTION
1. Extracting context.Context from the internals of the
Download.Start() method as placing it as parameters
allows fine graned control over the cancellation.
This breaks backwards compatibility!

2. Cancellation to the program in main binary - when system interrupts the program in any way
unfinished download should be removed from the system

Signed-off-by: Dusan Malusev <dusan.998@outlook.com>