### PR TITLE
Fall back to filename from URL when don't have it in the header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 dist/
 coverage.out
+*.dat
+*.output

--- a/download.go
+++ b/download.go
@@ -333,12 +333,13 @@ func (d *Download) Path() string {
 	// Set the default path
 	if d.path == "" {
 
+		d.path = GetFilename(d.URL) // default case
 		if d.Dest != "" {
 			d.path = d.Dest
 		} else if d.unsafeName != "" {
-			d.path = getNameFromHeader(d.unsafeName)
-		} else {
-			d.path = GetFilename(d.URL)
+			if path := getNameFromHeader(d.unsafeName); path != "" {
+				d.path = path
+			}
 		}
 		d.path = filepath.Join(d.Dir, d.path)
 	}


### PR DESCRIPTION

In case we have a valid header, we'll try to get unsafeName from it but we cannot do it:

```
content-disposition: attachment
```

So, we fall back to a default case, getting the filename right from the URL and fix it, if we have a filename in the content-disposition.