### PR TITLE
Fixing TestChunksLength [test is still broken]

### DIFF
--- a/chunks_test.go
+++ b/chunks_test.go
@@ -7,7 +7,7 @@ import (
 func TestChunksLength(t *testing.T) {
 
 	d := &Download{
-		URL:          "http://www.ovh.net/files/10Mio.dat",
+		URL:          "https://proof.ovh.net/files/10Mb.dat",
 		MinChunkSize: 5242870,
 	}
 

--- a/chunks_test.go
+++ b/chunks_test.go
@@ -29,6 +29,11 @@ func TestChunksLength(t *testing.T) {
 		End:   10485759,
 	}
 
+	if d.info.Rangeable == false {
+		t.Errorf("Chunk information could not be retrieved for the test file: %s", d.URL)
+		return
+	}
+
 	if d.chunks[0].Start != 0 {
 
 		t.Errorf("First chunk should start from 0, but got %d", d.chunks[0].Start)


### PR DESCRIPTION
Hi,

took another 5 min to fix the panic in the mentioned test. Seems `http://www.ovh.net` does not provide (anymore?) `content-range` header - just in case you would want to fix ultimately.

Cheers,
Peter