### PR TITLE
main.go: fix help text typo

### DIFF
--- a/cmd/got/main.go
+++ b/cmd/got/main.go
@@ -47,7 +47,7 @@ func main() {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "output",
-				Usage:   "Download `path`, if dir passed the path witll be `dir + output`.",
+				Usage:   "Download `path`, if dir passed the path will be `dir + output`.",
 				Aliases: []string{"o"},
 			},
 			&cli.StringFlag{

--- a/cmd/wgot/main.go
+++ b/cmd/wgot/main.go
@@ -47,7 +47,7 @@ func main() {
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:    "output",
-				Usage:   "Download `path`, if dir passed the path witll be `dir + output`.",
+				Usage:   "Download `path`, if dir passed the path will be `dir + output`.",
 				Aliases: []string{"o"},
 			},
 			&cli.StringFlag{


### PR DESCRIPTION
`witll` to `will`